### PR TITLE
Leak fix

### DIFF
--- a/queuebuilder.cpp
+++ b/queuebuilder.cpp
@@ -54,6 +54,12 @@ void QueueBuilder::run()
     long int counterOfTiles = 0;
     tileVector = new QVector<TileDataClass*>();
 
+    // initialize osmscout logger
+    osmscout::log.Debug(OsmScoutDebug);
+    osmscout::log.Info(true);
+    osmscout::log.Warn(true);
+    osmscout::log.Error(true);
+
     osmscout::AreaSearchParameter searchParameter;
     searchParameter.SetUseLowZoomOptimization(true);
     searchParameter.SetMaximumAreaLevel(3);

--- a/queuebuilder.h
+++ b/queuebuilder.h
@@ -28,6 +28,9 @@
 #include <osmscout/MapPainterQt.h>
 #include <osmscout/util/StopClock.h>
 #include <osmscout/util/Tiling.h>
+
+constexpr bool OsmScoutDebug = false;
+
 class QueueBuilder : public QThread
 {
     Q_OBJECT

--- a/renderclass.cpp
+++ b/renderclass.cpp
@@ -143,6 +143,9 @@ void RenderClass::run()
                         data,
                         &qp);
 
+        // data are not needed anymore
+        data.ClearDBData();
+
         std::string output=std::to_string(tileClass->zoom)+"_"+std::to_string(tileClass->x)+"_"+std::to_string(tileClass->y)+".ppm";
 
         pixmap.save(QString("offline_tiles/%0_100-l-%1-%2-%3-%4.png").arg("osm_custom").arg(1).arg(tileClass->zoom).arg(tileClass->x).arg(tileClass->y));

--- a/renderclass.cpp
+++ b/renderclass.cpp
@@ -38,6 +38,8 @@ void RenderClass::run()
     drawParameter.SetFontName("/usr/share/fonts/TTF/DejaVuSans.ttf");
     drawParameter.SetFontSize(2.0);
     drawParameter.SetDrawFadings(false);
+    drawParameter.SetDebugData(OsmScoutDebug);
+    drawParameter.SetDebugPerformance(OsmScoutDebug);
     searchParameter.SetUseLowZoomOptimization(true);
     searchParameter.SetMaximumAreaLevel(3);
 


### PR DESCRIPTION
map data are loaded for specific tile, they should be cleared when they are not needed anymore

should solve performance issue discussed here: https://github.com/Framstag/libosmscout/issues/1009